### PR TITLE
 Replace Autoprefixer browsers option with Browserslist config

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,7 +16,7 @@ function sass() {
     })
       .on('error', $.sass.logError))
     .pipe($.postcss([
-      autoprefixer({ browsers: ['last 2 versions', 'ie >= 9'] })
+      autoprefixer()
     ]))
     .pipe(gulp.dest('css'))
     .pipe(browserSync.stream());

--- a/package.json
+++ b/package.json
@@ -31,5 +31,9 @@
     "type": "git",
     "url": "https://github.com/zurb/foundation-sites-template.git"
   },
-  "private": true
+  "private": true,
+  "browserslist": [
+    "last 2 versions",
+    "ie >= 9"
+  ]
 }


### PR DESCRIPTION
Use browserslist key in package.json to prevent warning in sass build